### PR TITLE
Add multi-line comments; enhance error message

### DIFF
--- a/examples/xx.xx
+++ b/examples/xx.xx
@@ -22,7 +22,9 @@ $42, $42, $42, $42     │ 8 Bit
 │ Currently, multi line comments aren't supported
 └─────────────────────────────────────────────────────
 -- Lua Style
-// C Style
+/* C multi-
+line Style */
+// C++ Style
 # Python Style
 ; Nasm Style
 % MATLAB, PDF 


### PR DESCRIPTION
- Support C-style multi-line comments, eg:
```c
/* C multi-
line Style */
```
- Print unmodified line in error message