### PR TITLE
Fix string parsing

### DIFF
--- a/tests/stringtest.xx
+++ b/tests/stringtest.xx
@@ -1,0 +1,11 @@
+"This is a normal stringxxxxxxxxx" 0x00 12 34h $56 \x78   ;; Normal string
+"This string contains    4 spaces"    ;; These spaces will be preserved
+"A comment -- inside a stringAAAA"    ;; This comment needs to be preserved
+"    whitespace x4,either end    "    ;; The whitespace needs to be there
+"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	" ;; The last characted here is a literal tab
+"Test escapes \t\n\r"		
+"Many" "strings" "no" "spaces"
+"\n"  ;; This needs to generate 0a
+
+
+;; The shasum of the resulting file must be stringtest.47a56fa6.bin

--- a/xx.py
+++ b/xx.py
@@ -269,7 +269,12 @@ def tokenizeXX(xxline, lineNum):
             isEscape = True
             continue
         if isEscape:
-            buf += escapes[c]
+            # if an escape sequence is known then replace it, otherwise copy as is
+            if c in escapes:
+                buf += escapes[c]
+            else:
+                buf += "\\"
+                buf += c
             isEscape = False
             continue
         if c == '"':

--- a/xx.py
+++ b/xx.py
@@ -6,12 +6,14 @@ parser = argparse.ArgumentParser(description="xx")
 parser.add_argument('inFile', help='File to open')
 parser.add_argument('-x', dest='dumpHex', help='Dump hex instead of writing file', action="store_true")
 
-xxVersion = "0.4"
+xxVersion = "0.4.1"
 
 # Comments - The box drawing comments are generated when checking a token
 asciiComments = [ "#", ";", "%", "|","\x1b", "-", "/" ]
 twoCharComments = [ "--", "//", ]
 filterList = [",","$","\\x","0x","h",":"," "]
+# XXX: Add rest of the escape sequences, what do we support here?
+escapes = {"n":"\n", "\\":"\\", "t":"\t", "r":"\r"} # List of escape sequences to be interpreted when parsing quoted strings  
 
 class xxToken:
     """
@@ -35,6 +37,11 @@ class xxToken:
         self.isEnd = 0     # If the line ends with a double quote, this is marked as the end
         self.hexData = ""  # This is the fully parsed hex data that is passed to the main buffer to output
         self.hexDataLen = 0 # !! UNUSED, The length of the hex data, should match the length of normData
+    def __str__(self):
+        return f"t\"{self.rawData}\""
+    def __repr__(self):
+        byterepr = bytes(self.rawData, 'latin1')
+        return f"xxToken({byterepr}, lineNum={self.lineNum}, isComment={self.isComment})"
     def testASCII(self):
         """
         Tests if the token can be decoded as ASCII
@@ -124,7 +131,6 @@ class xxToken:
                 if self.isEnd:
                     tempString = tempString.split('"')[0]
                 self.hexData = ascii2hex(tempString)
-
 ################################################################################
 def getTokenAttributes(inTok):
     """
@@ -156,7 +162,8 @@ def ascii2hex(inString):
     """
     formatted = ""
     for char in inString:
-        hex_char = format(ord(char), "x")
+        
+        hex_char = format(ord(char), "02x")
         formatted += hex_char
     return formatted
 
@@ -245,6 +252,40 @@ def filterMultLineComments(multilineComment, joinedLine, line):
     return multilineComment, joinedLine, lineResult, mustContinue
 
 ################################################################################
+def tokenizeXX(xxline, lineNum):
+    # We cannot just split() the string, since it will corrupt repeated whitespace
+    # We have to interpret quoted string verbatim with no changes.
+    # XXX: newline.xx: Comment gets inserted into file; "\n" error
+    xxline = xxline.strip()
+    tokens = []
+    buf = ""
+    verbatim = False
+    isEscape = False
+    for c in xxline:
+        if c == "\\" and not isEscape and verbatim: # Interpret escape sequences
+            isEscape = True
+            continue
+        if isEscape:
+            buf += escapes[c]
+            isEscape = False
+            continue
+        if c == '"':
+            # When we find a quote, switch verbatim mode - this preserves
+            # whitespace and comment characters inside strings
+            verbatim = not verbatim 
+            continue
+        if c == " " and not verbatim:
+            # We split, but only if we are not inside a string rn
+            if buf != "":
+                # Avoid creating empty tokens if spaces are repeated.
+                tokens.append(xxToken(buf, lineNum, False, False))
+            buf = ""
+            continue
+        buf += c
+    tokens.append(xxToken(buf, lineNum, False, False)) # Append last token on EOL
+    return tokens
+
+
 def parseXX(xxFile):
     commentList = getCommentList()
     xxOut = b""
@@ -257,12 +298,11 @@ def parseXX(xxFile):
         multilineComment, joinedLine, line, mustContinue = filterMultLineComments(multilineComment, joinedLine, line)
         if mustContinue:
             continue
-        lineTokens = line.split()
+        lineTokens = tokenizeXX(line, lineNum)
         isComment = 0
         needsMore = 0
         linesHexData = ""
-        for lToken in lineTokens:
-            t = xxToken(lToken,lineNum,isComment,needsMore)
+        for t in lineTokens:
             getTokenAttributes(t)
             if t.isComment or t.hasComment:
                 isComment = 1

--- a/xx.py
+++ b/xx.py
@@ -135,7 +135,6 @@ class xxToken:
                     tempString = tempString.split('"')[1]
                 if self.isEnd:
                     tempString = tempString.split('"')[0]
-                print(f"gHFS: passing {tempString}EOD to a2h")
                 self.hexData = ascii2hex(tempString)
 ################################################################################
 def getTokenAttributes(inTok):
@@ -168,7 +167,6 @@ def ascii2hex(inString):
     """
     formatted = ""
     for char in inString:
-        
         hex_char = format(ord(char), "02x")
         formatted += hex_char
     return formatted
@@ -196,7 +194,6 @@ def testCharComment(inChar):
 
 ################################################################################
 def writeBin(b,h,file_name):
-    print(f"writebin received {b}EOD")
     """
     Writes the binary file
     """
@@ -204,7 +201,6 @@ def writeBin(b,h,file_name):
     with open(outfile,'wb') as f:
         f.write(b)
     print(outfile)
-
 def dHex(inBytes):
     """
     Does a simple hex dump, use yxd library later
@@ -268,7 +264,6 @@ def tokenizeXX(xxline, lineNum):
     buf = ""
     verbatim = False
     isEscape = False
-    
     for c in xxline:
         if c == "\\" and not isEscape and verbatim: # Interpret escape sequences
             isEscape = True
@@ -280,7 +275,7 @@ def tokenizeXX(xxline, lineNum):
         if c == '"':
             # When we find a quote, switch verbatim mode - this preserves
             # whitespace and comment characters inside strings
-            verbatim = not verbatim 
+            verbatim = not verbatim
             continue
         if c == " " and not verbatim:
             # We split, but only if we are not inside a string rn
@@ -291,13 +286,11 @@ def tokenizeXX(xxline, lineNum):
                     if k in buf:
                         isComment = True
                         break
-                print(f"token {buf} is a comment? {isComment}")
                 tokens.append(xxToken(buf, lineNum, isComment, False))
             buf = ""
             continue
         buf += c
     tokens.append(xxToken(buf, lineNum, False, False)) # Append last token on EOL
-    print(f"Line {xxline} => {tokens}")
     return tokens
 
 
@@ -318,9 +311,7 @@ def parseXX(xxFile):
         needsMore = 0
         linesHexData = ""
         for t in lineTokens:
-            print(f"parseXX: token is {t} hd={bytes(t.hexData, 'latin1')}")
             getTokenAttributes(t)
-            print(f"past GTA: {t}, hd={t.hexData}")
             if t.isComment or t.hasComment:
                 isComment = 1
                 break
@@ -328,11 +319,8 @@ def parseXX(xxFile):
                 needsMore = 1
             else:
                 needsMore = 0
-            print(f"parseXX: adding {t.hexData}EOD to lHD")
             linesHexData += t.hexData
-            print(f"parseXX: lHD is {linesHexData}EOD")
         xxOut += bytes.fromhex(linesHexData)
-        print(f"xxout is {xxOut}")
     return xxOut
 
 if __name__ == '__main__':


### PR DESCRIPTION
There was some serious issue with using `str.split()` to tokenize the line. `split()` does not preserve whitespace and we were dropping bytes.
This fixes string parsing, (see `tests/stringtest.xx`) and adds escape sequences to strings (for now just `\\`, `\n`, `\r`, `\t`). Undefined escape characters are copied as is.

This changes the token model a bit as strings are always 1 token now, so some of the `xxToken` fields are not necesary anymore (`isStart`, `isEnd`)

There is a bug which causes hex strings inside `"` to be interpreted as hex, ie. `"0a0b"` becomes "0x0a 0x0b", but it should be `0x30 0x61 0x30 0x62` but im not sure how to fix that yet

